### PR TITLE
Remove actions/checkout from TagBot template

### DIFF
--- a/templates/jlpkgbutler-tagbot-workflow.yml
+++ b/templates/jlpkgbutler-tagbot-workflow.yml
@@ -6,7 +6,6 @@ jobs:
   TagBot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It's no longer required, TagBot handles clones by itself.