### PR TITLE
Reduce TagBot frequency, add manual trigger

### DIFF
--- a/templates/jlpkgbutler-tagbot-workflow.yml
+++ b/templates/jlpkgbutler-tagbot-workflow.yml
@@ -1,7 +1,8 @@
 name: TagBot
 on:
   schedule:
-    - cron: 0 * * * *
+    - cron: 0 0 * * *
+  workflow_dispatch:
 jobs:
   TagBot:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Current recommendation is to run TagBot just once a day. Also, GitHub recently came out with a manual trigger which is the `workflow_dispatch` event.